### PR TITLE
Fix build raylib 5.0

### DIFF
--- a/src/raylib-tileson.cpp
+++ b/src/raylib-tileson.cpp
@@ -109,7 +109,7 @@ Map LoadTiledFromMemory(const unsigned char *fileData, int dataSize, const char*
 }
 
 Map LoadTiled(const char* fileName) {
-    unsigned int bytesRead;
+    int bytesRead;
     unsigned char* data = LoadFileData(fileName, &bytesRead);
     if (data == NULL || bytesRead == 0) {
         struct Map output;


### PR DESCRIPTION
- Fix build to work raylib 5.0
- Make tile import work with files in different directory than the working directory 
  - I kept LoadTiledFromMemory for backward compatibility, LoadTiledFromMemory cannot be fixed, it's locked behind encapsulation => maybe we should remove LoadTiledFromMemory